### PR TITLE
Revert "Fix warning for landingNormal prop"

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ AFRAME.registerComponent('teleport-controls', {
     curveMissColor: {type: 'color', default: '#ff0000'},
     curveShootingSpeed: {default: 5, min: 0, if: {type: ['parabolic']}},
     defaultPlaneSize: { default: 100 },
-    landingNormal: {type: 'vec3', default: { x: 0, y: 1, z: 0 },
+    landingNormal: {type: 'vec3', default: '0 1 0'},
     landingMaxAngle: {default: '45', min: 0, max: 360}
   },
 


### PR DESCRIPTION
This was supposed to go into hubs/master. Oops.